### PR TITLE
Remove extraneous +

### DIFF
--- a/randomForest/src/rf.c
+++ b/randomForest/src/rf.c
@@ -440,7 +440,7 @@ void classRF(double *x, int *dimx, int *cl, int *ncl, int *cat, int *maxcat,
             x[m + n*mdim] = tx[n];
             if (jin[n] == 0) {
               if (jvr[n] == cl[n]) {
-                +								nrightimp[cl[n] - 1]++;
+                nrightimp[cl[n] - 1]++;
                 nrightimpall++;
               }
               if (localImp && jvr[n] != jtr[n]) {


### PR DESCRIPTION
This was flagged by the `-W-unused-value` compiler flag. AFAICT the `+` is a typo, e.g. here is the line as originally added a long time ago:

https://github.com/cran/randomForest/blob/0bd66ef1db9ac01c821066e60c8f00f9cc8f810e/src/rf.c#L366-L371